### PR TITLE
Remove hardcoded references to startup command paths when run from copy is enabled

### DIFF
--- a/debian-8/init_container.sh
+++ b/debian-8/init_container.sh
@@ -19,60 +19,27 @@ cat /etc/motd
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 /usr/sbin/sshd
 
-appPath="/home/site/wwwroot/"
+appPath="/home/site/wwwroot"
+runFromPath="/tmp/webapp"
+sourcePath="/home/site/repository/"
+startupCommandPath="/opt/startup/startup.sh"
+defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 userStartupCommand="$@"
-
-function tryStripWwwRootPathFromInput() {
-    local originalArg="$1"
-    # Strip out the beginning of the argument if it starts with the the appPath
-    # Examples: /home/site/wwwroot/app.dll => app.dll
-    #           /home/site/wwwroot/app => app
-    if case $originalArg in $appPath*) true;; *) false;; esac; then
-        sanitizedArg="${originalArg/$appPath/}"
-        updatedPath="true"
-    else
-        sanitizedArg="$originalArg"
-    fi
-}
 
 # When run from copy is enabled, Oryx tries to run the app from a different directory (local to the container),
 # so sanitize any input arguments which still reference the wwwroot path. This is true for VS Publish scenarios.
 # Even though VS Publish team might fix this on their end, end users might not have upgraded their extension, so
 # this code needs to be present.
 if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
-    if [ $# -ne 0 ]; then
-        sanitizedInput=""
-        # Examples:
-        # ./app => ./app
-        # dotnet /home/site/wwwroot/app.dll => dotnet app.dll
-        # dotnet /home/site/wwwroot/app.dll /home/site/wwwroot/foo.config => dotnet app.dll foo.config
-        for arg in "$@"
-        do
-            tryStripWwwRootPathFromInput $arg
-            if [ -z "$sanitizedInput" ]; then
-                sanitizedInput="$sanitizedArg"
-            else
-                sanitizedInput="$sanitizedInput $sanitizedArg"
-            fi
-        done
-
-        if [ "$updatedPath" == "true" ]; then
-            echo "Updated startup command from '$@' to '$sanitizedInput'"
-        fi
-
-        userStartupCommand="$sanitizedInput"
-    fi
+    # Trim the ending '/'
+    appPath=$(echo "${appPath%/}")
+    runFromPath=$(echo "${runFromPath%/}")
+    userStartupCommand=$(echo $userStartupCommand | sed "s!$appPath!$runFromPath!g")
+    runFromPathArg="-runFromPath $runFromPath"
 fi
 
-sourcePath="/home/site/repository/"
-startupCommandPath="/opt/startup/startup.sh"
-defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 oryxArgs="-appPath $appPath -sourcePath $sourcePath -output $startupCommandPath -defaultAppFilePath $defaultAppPath \
-    -bindPort $PORT -userStartupCommand '$userStartupCommand'"
-
-if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
-    oryxArgs="-runFromPath /tmp/webapp $oryxArgs"
-fi
+    -bindPort $PORT -userStartupCommand '$userStartupCommand' $runFromPathArg"
 
 echo "Running oryx $oryxArgs"
 eval oryx $oryxArgs

--- a/debian-8/init_container.sh
+++ b/debian-8/init_container.sh
@@ -20,11 +20,55 @@ sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 /usr/sbin/sshd
 
 appPath="/home/site/wwwroot/"
+userStartupCommand="$@"
+
+function tryStripWwwRootPathFromInput() {
+    local originalArg="$1"
+    # Strip out the beginning of the argument if it starts with the the appPath
+    # Examples: /home/site/wwwroot/app.dll => app.dll
+    #           /home/site/wwwroot/app => app
+    if case $originalArg in $appPath*) true;; *) false;; esac; then
+        sanitizedArg="${originalArg/$appPath/}"
+        updatedPath="true"
+    else
+        sanitizedArg="$originalArg"
+    fi
+}
+
+# When run from copy is enabled, Oryx tries to run the app from a different directory (local to the container),
+# so sanitize any input arguments which still reference the wwwroot path. This is true for VS Publish scenarios.
+# Even though VS Publish team might fix this on their end, end users might not have upgraded their extension, so
+# this code needs to be present.
+if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
+    if [ $# -ne 0 ]; then
+        sanitizedInput=""
+        # Examples:
+        # ./app => ./app
+        # dotnet /home/site/wwwroot/app.dll => dotnet app.dll
+        # dotnet /home/site/wwwroot/app.dll /home/site/wwwroot/foo.config => dotnet app.dll foo.config
+        for arg in "$@"
+        do
+            tryStripWwwRootPathFromInput $arg
+            if [ -z "$sanitizedInput" ]; then
+                sanitizedInput="$sanitizedArg"
+            else
+                sanitizedInput="$sanitizedInput $sanitizedArg"
+            fi
+        done
+
+        if [ "$updatedPath" == "true" ]; then
+            echo "Updated startup command from '$@' to '$sanitizedInput'"
+        fi
+
+        userStartupCommand="$sanitizedInput"
+    fi
+fi
+
 sourcePath="/home/site/repository/"
 startupCommandPath="/opt/startup/startup.sh"
 defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 oryxArgs="-appPath $appPath -sourcePath $sourcePath -output $startupCommandPath -defaultAppFilePath $defaultAppPath \
-    -bindPort $PORT -userStartupCommand '$@'"
+    -bindPort $PORT -userStartupCommand '$userStartupCommand'"
 
 if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
     oryxArgs="-runFromPath /tmp/webapp $oryxArgs"

--- a/debian-9/init_container.sh
+++ b/debian-9/init_container.sh
@@ -19,60 +19,27 @@ cat /etc/motd
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 /usr/sbin/sshd
 
-appPath="/home/site/wwwroot/"
+appPath="/home/site/wwwroot"
+runFromPath="/tmp/webapp"
+sourcePath="/home/site/repository/"
+startupCommandPath="/opt/startup/startup.sh"
+defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 userStartupCommand="$@"
-
-function tryStripWwwRootPathFromInput() {
-    local originalArg="$1"
-    # Strip out the beginning of the argument if it starts with the the appPath
-    # Examples: /home/site/wwwroot/app.dll => app.dll
-    #           /home/site/wwwroot/app => app
-    if case $originalArg in $appPath*) true;; *) false;; esac; then
-        sanitizedArg="${originalArg/$appPath/}"
-        updatedPath="true"
-    else
-        sanitizedArg="$originalArg"
-    fi
-}
 
 # When run from copy is enabled, Oryx tries to run the app from a different directory (local to the container),
 # so sanitize any input arguments which still reference the wwwroot path. This is true for VS Publish scenarios.
 # Even though VS Publish team might fix this on their end, end users might not have upgraded their extension, so
 # this code needs to be present.
 if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
-    if [ $# -ne 0 ]; then
-        sanitizedInput=""
-        # Examples:
-        # ./app => ./app
-        # dotnet /home/site/wwwroot/app.dll => dotnet app.dll
-        # dotnet /home/site/wwwroot/app.dll /home/site/wwwroot/foo.config => dotnet app.dll foo.config
-        for arg in "$@"
-        do
-            tryStripWwwRootPathFromInput $arg
-            if [ -z "$sanitizedInput" ]; then
-                sanitizedInput="$sanitizedArg"
-            else
-                sanitizedInput="$sanitizedInput $sanitizedArg"
-            fi
-        done
-
-        if [ "$updatedPath" == "true" ]; then
-            echo "Updated startup command from '$@' to '$sanitizedInput'"
-        fi
-
-        userStartupCommand="$sanitizedInput"
-    fi
+    # Trim the ending '/'
+    appPath=$(echo "${appPath%/}")
+    runFromPath=$(echo "${runFromPath%/}")
+    userStartupCommand=$(echo $userStartupCommand | sed "s!$appPath!$runFromPath!g")
+    runFromPathArg="-runFromPath $runFromPath"
 fi
 
-sourcePath="/home/site/repository/"
-startupCommandPath="/opt/startup/startup.sh"
-defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 oryxArgs="-appPath $appPath -sourcePath $sourcePath -output $startupCommandPath -defaultAppFilePath $defaultAppPath \
-    -bindPort $PORT -userStartupCommand '$userStartupCommand'"
-
-if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
-    oryxArgs="-runFromPath /tmp/webapp $oryxArgs"
-fi
+    -bindPort $PORT -userStartupCommand '$userStartupCommand' $runFromPathArg"
 
 echo "Running oryx $oryxArgs"
 eval oryx $oryxArgs

--- a/debian-9/init_container.sh
+++ b/debian-9/init_container.sh
@@ -20,11 +20,55 @@ sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 /usr/sbin/sshd
 
 appPath="/home/site/wwwroot/"
+userStartupCommand="$@"
+
+function tryStripWwwRootPathFromInput() {
+    local originalArg="$1"
+    # Strip out the beginning of the argument if it starts with the the appPath
+    # Examples: /home/site/wwwroot/app.dll => app.dll
+    #           /home/site/wwwroot/app => app
+    if case $originalArg in $appPath*) true;; *) false;; esac; then
+        sanitizedArg="${originalArg/$appPath/}"
+        updatedPath="true"
+    else
+        sanitizedArg="$originalArg"
+    fi
+}
+
+# When run from copy is enabled, Oryx tries to run the app from a different directory (local to the container),
+# so sanitize any input arguments which still reference the wwwroot path. This is true for VS Publish scenarios.
+# Even though VS Publish team might fix this on their end, end users might not have upgraded their extension, so
+# this code needs to be present.
+if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
+    if [ $# -ne 0 ]; then
+        sanitizedInput=""
+        # Examples:
+        # ./app => ./app
+        # dotnet /home/site/wwwroot/app.dll => dotnet app.dll
+        # dotnet /home/site/wwwroot/app.dll /home/site/wwwroot/foo.config => dotnet app.dll foo.config
+        for arg in "$@"
+        do
+            tryStripWwwRootPathFromInput $arg
+            if [ -z "$sanitizedInput" ]; then
+                sanitizedInput="$sanitizedArg"
+            else
+                sanitizedInput="$sanitizedInput $sanitizedArg"
+            fi
+        done
+
+        if [ "$updatedPath" == "true" ]; then
+            echo "Updated startup command from '$@' to '$sanitizedInput'"
+        fi
+
+        userStartupCommand="$sanitizedInput"
+    fi
+fi
+
 sourcePath="/home/site/repository/"
 startupCommandPath="/opt/startup/startup.sh"
 defaultAppPath="/defaulthome/hostingstart/hostingstart.dll"
 oryxArgs="-appPath $appPath -sourcePath $sourcePath -output $startupCommandPath -defaultAppFilePath $defaultAppPath \
-    -bindPort $PORT -userStartupCommand '$@'"
+    -bindPort $PORT -userStartupCommand '$userStartupCommand'"
 
 if [ "$APP_SVC_RUN_FROM_COPY" = true ]; then
     oryxArgs="-runFromPath /tmp/webapp $oryxArgs"


### PR DESCRIPTION
cc @gpcastro @JennyLawrance 